### PR TITLE
pipeline improvements

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pipenv'
 
       - name: Install Pip amd Dependencies
         run: |

--- a/.github/workflows/tag_and_publish_package.yml
+++ b/.github/workflows/tag_and_publish_package.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
+          cache: 'pipenv'
 
       - name: Install Pip amd Dependencies
         run: |
@@ -39,7 +40,7 @@ jobs:
           echo "VERSION=$(pipenv run python tools/print_version.py)" >> $GITHUB_ENV
 
       - name: Tag Repository
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
             const tagName = '${{ env.VERSION }}';


### PR DESCRIPTION
I noticed the 3.12 tests were running a lot longer than 3.9-3.11. Added pipenv cache in hopes of speeding up the build/install 