### PR TITLE
release/0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v0.2.0
+- Introduce `market_metrics_all_cash`, `price_feed`, `price_feed_volatiltiy`. See [Parcl Labs Changelog](https://docs.parcllabs.com/changelog/market-all-cash-price-feed-price-feed-volatility-endpoints) for more details.
+
 ### v0.1.21
 - Bugfix on parsing for `new_rental_listings` metrics in `v1/investor_metrics/{parcl_id}/housing_event_prices`
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,43 @@ print(results.head())
 
 ## Services
 
-Services are the core of the Parcl Labs API. They provide access to a wide range of data and analytics on the housing market. The services are divided into the following categories: `Rental Market Metrics`, `For Sale Market Metrics`, `Market Metrics`, `Investor Metrics`, and `Portfolio Metrics`.
+Services are the core of the Parcl Labs API. They provide access to a wide range of data and analytics on the housing market. The services are divided into the following categories: `Price Feeds`, `Rental Market Metrics`, `For Sale Market Metrics`, `Market Metrics`, `Investor Metrics`, and `Portfolio Metrics`.
 
+### Price Feeds
+The Parcl Labs Price Feed (PLPF) is a daily-updated, real-time indicator of residential real estate prices, measured by price per square foot, across select US markets.
+
+The Price Feeds category allows you to access our daily-updated PLPF and derivative metrics, such as volatility.
+
+#### Price Feed
+Gets the daily price feed for a specified `parcl_id`.
+
+#### Price Feed Volatility
+Gets the daily price feed volatility for a specified `parcl_id`.
+
+```python
+import os
+
+from parcllabs import ParclLabsClient
+
+api_key = os.getenv('PARCLLABS_API_KEY')
+client = ParclLabsClient(api_key)
+
+# Get available Price Feed markets
+pricefeed_markets = client.search_markets.retrieve(
+        sort_by='PRICEFEED_MARKET',
+        sort_order='DESC',
+        params={'limit': 10},
+        as_dataframe=True
+)
+pricefeed_ids = pricefeed_markets['parcl_id'].tolist()
+
+price_feeds = client.price_feed.retrieve_many(parcl_ids=pricefeed_ids, as_dataframe=True)
+price_feed_volatility = client.price_feed_volatility.retrieve_many(parcl_ids=pricefeed_ids, as_dataframe=True)
+
+# want to save to csv? 
+price_feeds.to_csv('price_feeds.csv', index=False)
+price_feed_volatility.to_csv('price_feed_volatility.csv', index=False)
+```
 
 ### Rental Market Metrics
 
@@ -164,6 +199,9 @@ Gets housing stock for a specified `parcl_id`. Housing stock represents the tota
 #### Housing Event Prices
 Gets monthly statistics on prices for housing events, including sales, new for-sale listings, and new rental listings, based on a specified `parcl_id`.
 
+#### All Cash
+Gets monthly counts of all cash transactions and their percentage share of total sales, based on a specified <parcl_id> .
+
 
 ##### Get all market metrics
 ```python
@@ -203,6 +241,13 @@ results_housing_stock = client.market_metrics_housing_stock.retrieve_many(
 )
 
 results_housing_event_counts = client.market_metrics_housing_event_counts.retrieve_many(
+    parcl_ids=top_market_parcl_ids,
+    start_date=start_date,
+    end_date=end_date,
+    as_dataframe=True
+)
+
+results_all_cash = client.market_metrics_all_cash.retrieve_many(
     parcl_ids=top_market_parcl_ids,
     start_date=start_date,
     end_date=end_date,

--- a/parcllabs/__init__.py
+++ b/parcllabs/__init__.py
@@ -9,36 +9,3 @@ api_base = DEFAULT_API_BASE
 
 
 from parcllabs.parcllabs_client import ParclLabsClient
-
-
-from parcllabs.services.investor_metrics import (
-    InvestorMetricsHousingStockOwnership,
-    InvesetorMetricsNewListingsForSaleRollingCounts,
-    InvestorMetricsPurchaseToSaleRatio,
-    InvestorMetricsHousingEventCounts,
-    InvestorMetricsHousingEventPrices,
-)
-
-from parcllabs.services.market_metrics import (
-    MarketMetricsHousingEventPrices,
-    MarketMetricsHousingStock,
-    MarketMetricsHousingEventCounts,
-)
-
-from parcllabs.services.for_sale_market_metrics import (
-    ForSaleMarketMetricsNewListingsRollingCounts,
-)
-
-from parcllabs.services.rental_market_metrics import (
-    RentalMarketMetricsRentalUnitsConcentration,
-    RentalMarketMetricsGrossYield,
-    RentalMarketMetricsNewListingsForRentRollingCounts,
-)
-
-from parcllabs.services.portfolio_metrics import (
-    PortfolioMetricsSFHousingStockOwnership,
-    PortfolioMetricsSFNewListingsForSaleRollingCounts,
-    PortfolioMetricsSFHousingEventCounts,
-    PortfolioMetricsSFNewListingsForRentRollingCounts,
-)
-from parcllabs.services.search import SearchMarkets

--- a/parcllabs/__version__.py
+++ b/parcllabs/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.21"
+VERSION = "0.2.0"

--- a/parcllabs/parcllabs_client.py
+++ b/parcllabs/parcllabs_client.py
@@ -5,6 +5,11 @@ from requests.exceptions import RequestException
 
 from parcllabs import api_base
 
+
+from parcllabs.services.price_feed import (
+    PriceFeedBase,
+)
+
 from parcllabs.services.investor_metrics import (
     InvestorMetricsHousingStockOwnership,
     InvesetorMetricsNewListingsForSaleRollingCounts,
@@ -14,6 +19,7 @@ from parcllabs.services.investor_metrics import (
 )
 
 from parcllabs.services.market_metrics import (
+    MarketMetricsAllCash,
     MarketMetricsHousingEventPrices,
     MarketMetricsHousingStock,
     MarketMetricsHousingEventCounts,
@@ -60,6 +66,14 @@ class ParclLabsClient:
         self.api_url = api_base
         self.limit = limit
 
+        # price feed services
+        self.price_feed = PriceFeedBase(
+            url="/v1/price_feed/{parcl_id}/price_feed", client=self
+        )
+        self.price_feed_volatility = PriceFeedBase(
+            url="/v1/price_feed/{parcl_id}/volatility", client=self
+        )
+
         # top-level services: The client is responsible for creating instances of these services
         self.investor_metrics_housing_stock_ownership = (
             InvestorMetricsHousingStockOwnership(client=self)
@@ -79,6 +93,7 @@ class ParclLabsClient:
         self.market_metrics_housing_event_prices = MarketMetricsHousingEventPrices(
             client=self
         )
+        self.market_metrics_all_cash = MarketMetricsAllCash(client=self)
         self.market_metrics_housing_stock = MarketMetricsHousingStock(client=self)
         self.market_metrics_housing_event_counts = MarketMetricsHousingEventCounts(
             client=self

--- a/parcllabs/services/market_metrics.py
+++ b/parcllabs/services/market_metrics.py
@@ -5,6 +5,64 @@ import pandas as pd
 from parcllabs.services.parcllabs_service import ParclLabsService
 
 
+class MarketMetricsAllCash(ParclLabsService):
+    """
+    Gets monthly counts of all cash transactions and their percentage share of total sales, based on a specified <parcl_id> .
+    """
+
+    def retrieve(
+        self,
+        parcl_id: int,
+        start_date: str = None,
+        end_date: str = None,
+        property_type: str = None,
+        params: Optional[Mapping[str, Any]] = None,
+        as_dataframe: bool = False,
+    ):
+        start_date = self.validate_date(start_date)
+        end_date = self.validate_date(end_date)
+        property_type = self.validate_property_type(property_type)
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+            "property_type": property_type,
+            **(params or {}),
+        }
+        results = self._request(
+            url=f"/v1/market_metrics/{parcl_id}/all_cash", params=params
+        )
+
+        if as_dataframe:
+            fmt = {results.get("parcl_id"): results.get("items")}
+            return self._as_pd_dataframe(fmt)
+        return results
+
+    def retrieve_many(
+        self,
+        parcl_ids: List[int],
+        start_date: str = None,
+        end_date: str = None,
+        property_type: str = None,
+        params: Optional[Mapping[str, Any]] = None,
+        as_dataframe: bool = False,
+    ):
+        start_date = self.validate_date(start_date)
+        end_date = self.validate_date(end_date)
+        property_type = self.validate_property_type(property_type)
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+            "property_type": property_type,
+            **(params or {}),
+        }
+        results, _ = self.retrieve_many_items(parcl_ids=parcl_ids, params=params)
+
+        if as_dataframe:
+            return self._as_pd_dataframe(results)
+
+        return results
+
+
 class MarketMetricsHousingEventCounts(ParclLabsService):
     """
     Gets monthly counts of housing events, including sales, new sale listings, and new rental listings, based on a specified <parcl_id>.

--- a/parcllabs/services/price_feed.py
+++ b/parcllabs/services/price_feed.py
@@ -1,0 +1,63 @@
+from typing import Any, Mapping, Optional, List
+
+from parcllabs.services.parcllabs_service import ParclLabsService
+
+
+class PriceFeedBase(ParclLabsService):
+    """
+    Base class for price feed services.
+    """
+
+    def __init__(self, url: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.url = url
+
+    def retrieve(
+        self,
+        parcl_id: int,
+        start_date: str = None,
+        end_date: str = None,
+        params: Optional[Mapping[str, Any]] = None,
+        as_dataframe: bool = False,
+    ):
+        start_date = self.validate_date(start_date)
+        end_date = self.validate_date(end_date)
+
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+            **(params or {}),
+        }
+        results = self._request(
+            url=self.url.format(parcl_id=parcl_id),
+            params=params,
+        )
+
+        if as_dataframe:
+            fmt = {results.get("parcl_id"): results.get("items")}
+            return self._as_pd_dataframe(fmt)
+
+        return results
+
+    def retrieve_many(
+        self,
+        parcl_ids: List[int],
+        start_date: str = None,
+        end_date: str = None,
+        params: Optional[Mapping[str, Any]] = None,
+        as_dataframe: bool = False,
+    ):
+        start_date = self.validate_date(start_date)
+        end_date = self.validate_date(end_date)
+
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+            **(params or {}),
+        }
+        results, _ = self.retrieve_many_items(parcl_ids=parcl_ids, params=params)
+
+        if as_dataframe:
+            return self._as_pd_dataframe(results)
+
+        return results

--- a/tests/test_price_feed.py
+++ b/tests/test_price_feed.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import Mock
+from requests.exceptions import HTTPError
+
+import pandas as pd
+
+from parcllabs.services.price_feed import (
+    PriceFeedBase,
+)
+
+
+# Mock client and service setup
+@pytest.fixture
+def mock_client():
+    client = Mock()
+    client.get.return_value = {"data": "mocked response"}
+    return client
+
+
+@pytest.fixture
+def service(mock_client):
+    return PriceFeedBase(client=mock_client, url="/v1/price_feed/{parcl_id}/price_feed")
+
+
+@pytest.fixture
+def api_response():
+    return {
+        "parcl_id": 101,
+        "items": [
+            {"date": "2024-05-14", "price_feed": 392.66},
+            {"date": "2024-05-13", "price_feed": 391.86},
+            {"date": "2024-05-12", "price_feed": 391.27},
+            {"date": "2024-05-11", "price_feed": 390.92},
+        ],
+    }
+
+
+def test_retrieve_success(service, mock_client, api_response):
+    mock_client.get.return_value = api_response
+    result = service.retrieve(
+        parcl_id=101,
+        start_date="2023-05-11",
+        end_date="2023-05-14",
+    )
+    assert result == api_response
+    assert mock_client.get.called
+    assert mock_client.get.call_args[1]["params"]["start_date"] == "2023-05-11"
+
+
+def test_retrieve_as_dataframe(service, mock_client, api_response):
+    mock_client.get.return_value = api_response
+    result = service.retrieve(
+        parcl_id=101,
+        start_date="2023-05-11",
+        end_date="2023-05-14",
+        as_dataframe=True,
+    )
+    assert isinstance(result, pd.DataFrame)
+    assert "parcl_id" in result.columns


### PR DESCRIPTION
### v0.2.0
- Introduce `market_metrics_all_cash`, `price_feed`, `price_feed_volatiltiy`. See [Parcl Labs Changelog](https://docs.parcllabs.com/changelog/market-all-cash-price-feed-price-feed-volatility-endpoints) for more details.