### PR TITLE
Release/0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v0.4.0
+- Introduce `for_sale_inventory`. See [Parcl Labs Changelog](https://docs.parcllabs.com/changelog/for-sale-market-metrics-for-sale-inventory) for more details.
+
 ### v0.3.0
 - Introduce `price_feed_rentals`. See [Parcl Labs Changelog](https://docs.parcllabs.com/changelog/price-feed-rental-price-feed) for more details.
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ rentals_new_listings_rolling_counts = client.rental_market_metrics_new_listings_
 #### New Listings Rolling Counts
 Gets weekly updated rolling counts of newly listed for sale properties, segmented into 7, 30, 60, and 90 day periods ending on a specified date, based on a given `parcl_id`.
 
+#### For Sale Inventory
+Gets the weekly updated current count of total inventory listed on market for sale, based on a specified `parcl_id` . The data series for the for sale inventory begins on September 1, 2022 (2022-09-01).
+
 
 ##### Get all for sale market metrics
 ```python
@@ -191,6 +194,13 @@ results_for_sale_new_listings = client.for_sale_market_metrics_new_listings_roll
     start_date=start_date,
     end_date=end_date,
     property_type=property_type,
+    as_dataframe=True
+)
+
+for_sale_inventory = client.for_sale_market_metrics_for_sale_inventory(
+    parcl_ids=top_market_parcl_ids,
+    start_date=start_date,
+    end_date=end_date,
     as_dataframe=True
 )
 ```

--- a/parcllabs/__version__.py
+++ b/parcllabs/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.3.0"
+VERSION = "0.4.0"

--- a/parcllabs/parcllabs_client.py
+++ b/parcllabs/parcllabs_client.py
@@ -26,7 +26,7 @@ from parcllabs.services.market_metrics import (
 )
 
 from parcllabs.services.for_sale_market_metrics import (
-    ForSaleMarketMetricsNewListingsRollingCounts,
+    ForSaleMarketMetricsBaseService,
 )
 
 from parcllabs.services.rental_market_metrics import (
@@ -102,9 +102,18 @@ class ParclLabsClient:
         self.market_metrics_housing_event_counts = MarketMetricsHousingEventCounts(
             client=self
         )
-        self.for_sale_market_metrics_new_listings_rolling_counts = (
-            ForSaleMarketMetricsNewListingsRollingCounts(client=self)
+
+        # for sale market metrics
+        self.for_sale_market_metrics_new_listings_rolling_counts = ForSaleMarketMetricsBaseService(
+            url="/v1/for_sale_market_metrics/{parcl_id}/new_listings_rolling_counts",
+            client=self
         )
+
+        self.for_sale_market_metrics_for_sale_inventory = ForSaleMarketMetricsBaseService(
+            url="/v1/for_sale_market_metrics/{parcl_id}/for_sale_inventory",
+            client=self
+        )
+
         self.rental_market_metrics_rental_units_concentration = (
             RentalMarketMetricsRentalUnitsConcentration(client=self)
         )

--- a/parcllabs/services/for_sale_market_metrics.py
+++ b/parcllabs/services/for_sale_market_metrics.py
@@ -6,10 +6,14 @@ import pandas as pd
 from parcllabs.services.parcllabs_service import ParclLabsService
 
 
-class ForSaleMarketMetricsNewListingsRollingCounts(ParclLabsService):
+class ForSaleMarketMetricsBaseService(ParclLabsService):
     """
-    Gets weekly updated rolling counts of newly listed for sale properties, segmented into 7, 30, 60, and 90 day periods ending on a specified date, based on a given <parcl_id>.
+    Base class for for sale market metrics services.
     """
+
+    def __init__(self, url: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.url = url
 
     def retrieve(
         self,
@@ -30,7 +34,7 @@ class ForSaleMarketMetricsNewListingsRollingCounts(ParclLabsService):
             **(params or {}),
         }
         results = self._request(
-            url=f"/v1/for_sale_market_metrics/{parcl_id}/new_listings_rolling_counts",
+            url=self.url.format(parcl_id=parcl_id),
             params=params,
         )
 

--- a/tests/test_for_sale_for_sale_inventory.py
+++ b/tests/test_for_sale_for_sale_inventory.py
@@ -20,7 +20,7 @@ def mock_client():
 @pytest.fixture
 def service(mock_client):
     return ForSaleMarketMetricsBaseService(
-        url='/v1/for_sale_market_metrics/{parcl_id}/new_listings_rolling_counts',
+        url='/v1/for_sale_market_metrics/{parcl_id}/for_sale_inventory',
         client=mock_client
     )
 


### PR DESCRIPTION
### v0.4.0
- Introduce `for_sale_inventory`. See [Parcl Labs Changelog](https://docs.parcllabs.com/changelog/for-sale-market-metrics-for-sale-inventory) for more details.
