### PR TITLE
release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v0.5.0
+- Introduce `for_sale_inventory_price_changes` and `housing_event_property_attributes`. See [Parcl Labs Changelog](https://docs.parcllabs.com/changelog/for-sale-market-metrics-inventory-prices-market-metrics-housing-event-property-attributes) for more details. 
+
 ### v0.4.2
 - Add `auto_paginate` support for all endpoints (retrieve & retrieve_many)
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Gets weekly updated rolling counts of newly listed for sale properties, segmente
 #### For Sale Inventory
 Gets the weekly updated current count of total inventory listed on market for sale, based on a specified `parcl_id` . The data series for the for sale inventory begins on September 1, 2022 (2022-09-01).
 
+#### For Sale Inventory Price Changes
+Gets weekly updated metrics on the price behavior of current for sale inventory, based on a specified `parcl_id`. Available metrics include the count of price changes, count of price drops, median days between price changes, median price change, and the percentage of inventory with price changes. The data series for the for sale inventory metrics begins on September 1, 2022 (2022-09-01).
 
 ##### Get all for sale market metrics
 ```python
@@ -203,6 +205,13 @@ for_sale_inventory = client.for_sale_market_metrics_for_sale_inventory(
     end_date=end_date,
     as_dataframe=True
 )
+
+for_sale_inventory_price_changes = client.for_sale_market_metrics_for_sale_inventory_price_changes.retrieve_many(
+        parcl_ids=top_market_parcl_ids,
+        start_date=start_date,
+        end_date=end_date,
+        as_dataframe=True,
+    )
 ```
 
 ### Market Metrics
@@ -215,6 +224,9 @@ Gets housing stock for a specified `parcl_id`. Housing stock represents the tota
 
 #### Housing Event Prices
 Gets monthly statistics on prices for housing events, including sales, new for-sale listings, and new rental listings, based on a specified `parcl_id`.
+
+#### Housing Event Property Attributes
+Gets monthly statistics on the physical attributes of properties involved in housing events, including sales, new for sale listings, and new rental listings, based on a specified `parcl_id`.
 
 #### All Cash
 Gets monthly counts of all cash transactions and their percentage share of total sales, based on a specified <parcl_id> .
@@ -262,6 +274,13 @@ results_housing_event_counts = client.market_metrics_housing_event_counts.retrie
     start_date=start_date,
     end_date=end_date,
     as_dataframe=True
+)
+
+housing_event_property_attributes = client.market_metrics_housing_event_property_attributes.retrieve_many(
+        parcl_ids=top_market_parcl_ids,
+        start_date=start_date,
+        end_date=end_date,
+        as_dataframe=True,
 )
 
 results_all_cash = client.market_metrics_all_cash.retrieve_many(

--- a/parcllabs/__version__.py
+++ b/parcllabs/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.4.2"
+VERSION = "0.5.0"

--- a/parcllabs/parcllabs_client.py
+++ b/parcllabs/parcllabs_client.py
@@ -74,6 +74,10 @@ class ParclLabsClient:
         self.market_metrics_housing_event_counts = PropertyTypeService(
             url="/v1/market_metrics/{parcl_id}/housing_event_counts", client=self
         )
+        self.market_metrics_housing_event_property_attributes = PropertyTypeService(
+            url="/v1/market_metrics/{parcl_id}/housing_event_property_attributes",
+            client=self,
+        )
 
         # for sale market metrics
         self.for_sale_market_metrics_new_listings_rolling_counts = PropertyTypeService(
@@ -82,6 +86,10 @@ class ParclLabsClient:
         )
         self.for_sale_market_metrics_for_sale_inventory = PropertyTypeService(
             url="/v1/for_sale_market_metrics/{parcl_id}/for_sale_inventory",
+            client=self,
+        )
+        self.for_sale_market_metrics_for_sale_inventory_price_changes = PropertyTypeService(
+            url="/v1/for_sale_market_metrics/{parcl_id}/for_sale_inventory_price_changes",
             client=self,
         )
 


### PR DESCRIPTION
### v0.5.0
- Introduce `for_sale_inventory_price_changes` and `housing_event_property_attributes`. See [Parcl Labs Changelog](https://docs.parcllabs.com/changelog/for-sale-market-metrics-inventory-prices-market-metrics-housing-event-property-attributes) for more details. 