### PR TITLE
remove mutable param

### DIFF
--- a/parcllabs/schemas/schemas.py
+++ b/parcllabs/schemas/schemas.py
@@ -5,7 +5,7 @@ Pydantic schemas for PropertyV2Service input parameters.
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, ValidationInfo, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from parcllabs.enums import PropertyTypes, RequestLimits
 
@@ -328,12 +328,11 @@ class PropertyV2RetrieveParams(BaseModel):
                     )
         return v
 
-    class Config:
-        """Pydantic configuration."""
-
-        extra = "forbid"  # Reject any extra fields
-        validate_assignment = True  # Validate on assignment
-        str_strip_whitespace = True  # Strip whitespace from strings
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True,
+        str_strip_whitespace=True,
+    )
 
 
 class PropertyV2RetrieveParamCategories(BaseModel):

--- a/parcllabs/services/metrics/portfolio_size_service.py
+++ b/parcllabs/services/metrics/portfolio_size_service.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from typing import Any
 
 import pandas as pd
@@ -14,12 +13,15 @@ class PortfolioSizeService(ParclLabsService):
         end_date: str | None = None,
         portfolio_size: str | None = None,
         limit: int | None = None,
-        params: Mapping[str, Any] | None = {},
+        params: dict[str, Any] | None = None,
         auto_paginate: bool = False,
     ) -> pd.DataFrame:
         """
         Retrieve portfolio size metrics for given parameters.
         """
+        if params is None:
+            params = {}
+
         if portfolio_size:
             params["portfolio_size"] = portfolio_size.upper()
 

--- a/parcllabs/services/metrics/property_type_service.py
+++ b/parcllabs/services/metrics/property_type_service.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from typing import Any
 
 import pandas as pd
@@ -14,12 +13,15 @@ class PropertyTypeService(ParclLabsService):
         end_date: str | None = None,
         property_type: str | None = None,
         limit: int | None = None,
-        params: Mapping[str, Any] | None = {},
+        params: dict[str, Any] | None = None,
         auto_paginate: bool = False,
     ) -> pd.DataFrame:
         """
         Retrieve property type metrics for given parameters.
         """
+        if params is None:
+            params = {}
+
         if property_type:
             params["property_type"] = property_type.upper()
 

--- a/parcllabs/services/properties/property_events_service.py
+++ b/parcllabs/services/properties/property_events_service.py
@@ -1,5 +1,4 @@
 from collections import deque
-from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
@@ -67,11 +66,14 @@ class PropertyEventsService(ParclLabsService):
         entity_owner_name: str | None = None,
         record_updated_date_start: str | None = None,
         record_updated_date_end: str | None = None,
-        params: Mapping[str, Any] | None = {},
+        params: dict[str, Any] | None = None,
     ) -> pd.DataFrame:
         """
         Retrieve property events for given parameters.
         """
+        if params is None:
+            params = {}
+
         params = self._prepare_params(
             event_type=event_type,
             start_date=start_date,


### PR DESCRIPTION
- Fix mutable default argument (`params={}`) in `PortfolioSizeService.retrieve()`, `PropertyTypeService.retrieve()`, and `PropertyEventsService.retrieve()`
- The shared default dict caused `portfolio_size` and `property_type` values to silently leak into subsequent calls that omitted the params argument
- Changed to idiomatic `params=None` with `if params is None: params = {}` guard in the function body
- Changed from deprecated `config` to `ConfigDict` in pydantic model configs